### PR TITLE
Set appropriate default instance names for the 'syntax' section

### DIFF
--- a/ReferenceGenerator/src/writers/BaseWriter.java
+++ b/ReferenceGenerator/src/writers/BaseWriter.java
@@ -398,7 +398,7 @@ public class BaseWriter {
       return s.substring(s.indexOf(" "));
     }
     if (!element.getModifiers().contains(Modifier.STATIC)) {
-      return "any variable of type " + element.getEnclosingElement().getSimpleName().toString();
+      return "your " + element.getEnclosingElement().getSimpleName().toString() + " object";
     }
     return "";
   }

--- a/ReferenceGenerator/src/writers/BaseWriter.java
+++ b/ReferenceGenerator/src/writers/BaseWriter.java
@@ -368,17 +368,23 @@ public class BaseWriter {
   }
 
   protected static String getInstanceName(Element element) {
-    List<String> tags = Shared
-      .i()
-      .getTags(element.getEnclosingElement())
-      .get("instanceName");
-    if (tags != null && tags.size() > 0) {
-      return tags.get(0).split("\\s")[0];
-    }
     if (element.getModifiers().contains(Modifier.STATIC)) {
+      // always use original class name for static methods
       return element.getEnclosingElement().getSimpleName().toString();
     } else {
-      return element.getEnclosingElement().getSimpleName().toString().toLowerCase();
+      // TODO add some coloration and/or italics around the instance name to 
+      // signify "this can/needs to be changed"
+      List<String> tags = Shared
+        .i()
+        .getTags(element.getEnclosingElement())
+        .get("instanceName");
+      if (tags != null && tags.size() > 0) {
+        // use the javadoc @instanceName if there is one
+        return tags.get(0).split("\\s")[0];
+      } else {
+        // if none, default to "myClassName"
+        return "my" + element.getEnclosingElement().getSimpleName().toString();
+      }
     }
   }
 
@@ -391,9 +397,9 @@ public class BaseWriter {
       String s = tags.get(0);
       return s.substring(s.indexOf(" "));
     }
-    // if (!element.getModifiers().contains(Modifier.STATIC)) {
-    //   return "any object of type " + element.getEnclosingElement().getSimpleName().toString();
-    // }
+    if (!element.getModifiers().contains(Modifier.STATIC)) {
+      return "any variable of type " + element.getEnclosingElement().getSimpleName().toString();
+    }
     return "";
   }
 

--- a/ReferenceGenerator/src/writers/BaseWriter.java
+++ b/ReferenceGenerator/src/writers/BaseWriter.java
@@ -375,7 +375,11 @@ public class BaseWriter {
     if (tags != null && tags.size() > 0) {
       return tags.get(0).split("\\s")[0];
     }
-    return "";
+    if (element.getModifiers().contains(Modifier.STATIC)) {
+      return element.getEnclosingElement().getSimpleName().toString();
+    } else {
+      return element.getEnclosingElement().getSimpleName().toString().toLowerCase();
+    }
   }
 
   protected static String getInstanceDescription(Element element) {
@@ -387,6 +391,9 @@ public class BaseWriter {
       String s = tags.get(0);
       return s.substring(s.indexOf(" "));
     }
+    // if (!element.getModifiers().contains(Modifier.STATIC)) {
+    //   return "any object of type " + element.getEnclosingElement().getSimpleName().toString();
+    // }
     return "";
   }
 


### PR DESCRIPTION
Many core libraries (such as Hardware I/O, Video and Sound) lack `@instanceName` annotations on their classes, which leads to misleading 'syntax' sections of their method references already noted in processing/processing-website#397 (see e.g. [`movieObject.available()`](https://processing.org/reference/libraries/video/Movie_available_.html)) which only look like:

> Syntax
> `.methodName()`

Those classes which do have an explicit `@instanceName` annotation (such as the Serial library) use the same instance name and description for static methods, which is also misleading (e.g. in the case of [`Serial.list()`](https://processing.org/reference/libraries/serial/Serial_list_.html)):

> Syntax
> `serial.list()`
> Parameters
> `serial`	(Serial)	any variable of type Serial

This pull request sets a non-empty default instance name which is the exact class name (for static methods) or a lower case version of the class name (for instance methods). If desired it would also be possible to add a default instance description that follows the conventions of the Processing core classes or Serial library ("any object/variable of type ...")